### PR TITLE
bug fix, the inject dll js file path should be absolute

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -155,7 +155,7 @@ const getAssetHtmlPluginDefaultArg = filepath => {
         filepath,
         includeSourcemap: false,
         typeOfAsset: typeOfAsset,
-        publicPath: typeOfAsset,
+        publicPath: '/' + typeOfAsset,
         outputPath: typeOfAsset
     }
 }


### PR DESCRIPTION
hello, i found bug and fixed it.
i changed the file `src/helper.js` at line 158, change publicPath to absolute.