### PR TITLE
Don't filter plugin: optimize-cssnano-plugin

### DIFF
--- a/service.js
+++ b/service.js
@@ -94,6 +94,7 @@ module.exports = (api, options) => {
             let FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin')
             let NamedChunksPlugin = require('webpack/lib/NamedChunksPlugin')
             let MiniCssExtreactPlugin = require('mini-css-extract-plugin')
+            let OptimizeCssnanoPlugin = require('@intervolga/optimize-cssnano-plugin')
             let fs = require('fs-extra')
 
             // filter plugins
@@ -106,7 +107,8 @@ module.exports = (api, options) => {
                     NamedChunksPlugin,
                     MiniCssExtreactPlugin,
                     webpack.DllPlugin,
-                    FileNameCachePlugin
+                    FileNameCachePlugin,
+                    OptimizeCssnanoPlugin
                 )
             )
 


### PR DESCRIPTION
Vue-Cli uses `@intervolga/optimize-cssnano-plugin` plugin to minify css.

I need to use it to remove css comments.

Vue-Cli code: 
https://github.com/vuejs/vue-cli/blob/1a0b59142aa8797810ca90705290d960a4ee6d1e/packages/%40vue/cli-service/lib/config/css.js#L242-L249